### PR TITLE
Image rotation setting

### DIFF
--- a/physiolabxr/_ui/OptionsWindowPlotFormatWidget.ui
+++ b/physiolabxr/_ui/OptionsWindowPlotFormatWidget.ui
@@ -20,7 +20,7 @@
    <item>
     <widget class="QTabWidget" name="plotFormatTabWidget">
      <property name="currentIndex">
-      <number>0</number>
+      <number>1</number>
      </property>
      <property name="iconSize">
       <size>
@@ -133,10 +133,47 @@
             <x>0</x>
             <y>0</y>
             <width>809</width>
-            <height>362</height>
+            <height>410</height>
            </rect>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_13">
+           <item>
+            <widget class="QWidget" name="display_rotation_widget" native="true">
+             <layout class="QHBoxLayout" name="horizontalLayout_7">
+              <item>
+               <widget class="QLabel" name="label_23">
+                <property name="text">
+                 <string>Rotation (Clockwise in Degree)</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QComboBox" name="comboBox">
+                <item>
+                 <property name="text">
+                  <string>0</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>90</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>180</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>270</string>
+                 </property>
+                </item>
+               </widget>
+              </item>
+             </layout>
+            </widget>
+           </item>
            <item>
             <widget class="QWidget" name="display_options" native="true">
              <layout class="QVBoxLayout" name="verticalLayout_12">

--- a/physiolabxr/_ui/OptionsWindowPlotFormatWidget.ui
+++ b/physiolabxr/_ui/OptionsWindowPlotFormatWidget.ui
@@ -138,17 +138,17 @@
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_13">
            <item>
-            <widget class="QWidget" name="display_rotation_widget" native="true">
+            <widget class="QWidget" name="image_rotation_clockwise_degree_widget" native="true">
              <layout class="QHBoxLayout" name="horizontalLayout_7">
               <item>
-               <widget class="QLabel" name="label_23">
+               <widget class="QLabel" name="image_rotation_clockwise_degree_label">
                 <property name="text">
                  <string>Rotation (Clockwise in Degree)</string>
                 </property>
                </widget>
               </item>
               <item>
-               <widget class="QComboBox" name="comboBox">
+               <widget class="QComboBox" name="image_rotation_clockwise_degree_combobox">
                 <item>
                  <property name="text">
                   <string>0</string>

--- a/physiolabxr/presets/PlotConfig.py
+++ b/physiolabxr/presets/PlotConfig.py
@@ -31,6 +31,7 @@ class ImageConfig(metaclass=SubPreset):
 
     width: int = 0
     height: int = 0
+    rotation_degree: int = 0
     scaling_percentage: float = 100
 
     cmap: Cmap = Cmap.VIRIDIS

--- a/physiolabxr/presets/PlotConfig.py
+++ b/physiolabxr/presets/PlotConfig.py
@@ -31,7 +31,7 @@ class ImageConfig(metaclass=SubPreset):
 
     width: int = 0
     height: int = 0
-    rotation_degree: int = 0
+    rotation_clockwise_degree: int = 0
     scaling_percentage: float = 100
 
     cmap: Cmap = Cmap.VIRIDIS

--- a/physiolabxr/presets/presets_utils.py
+++ b/physiolabxr/presets/presets_utils.py
@@ -119,6 +119,9 @@ def get_bar_chart_max_min_range(stream_name, group_name) -> tuple[float, float]:
 def set_group_image_format(stream_name, group_name, image_format):
     Presets().stream_presets[stream_name].group_info[group_name].plot_configs.image_config.image_format = image_format
 
+def set_group_image_rotation_clockwise_degree(stream_name, group_name, rotation_clockwise_degree):
+    Presets().stream_presets[stream_name].group_info[group_name].plot_configs.image_config.rotation_clockwise_degree = rotation_clockwise_degree
+
 def get_group_image_format(stream_name, group_name):
     return Presets().stream_presets[stream_name].group_info[group_name].plot_configs.image_config.image_format
 

--- a/physiolabxr/ui/OptionsWindowPlotFormatWidget.py
+++ b/physiolabxr/ui/OptionsWindowPlotFormatWidget.py
@@ -15,7 +15,7 @@ from physiolabxr.presets.presets_utils import get_stream_a_group_info, \
     set_spectrogram_percentile_level_min, set_spectrogram_percentile_level_max, set_image_levels_max, \
     set_image_levels_min, get_valid_image_levels, set_image_cmap, \
     set_image_levels_rmin, set_image_levels_bmax, set_image_levels_bmin, set_image_levels_gmax, set_image_levels_gmin, \
-    set_image_levels_rmax, set_image_scaling_percentile, get_image_levels
+    set_image_levels_rmax, set_image_scaling_percentile, get_image_levels, set_group_image_rotation_clockwise_degree
 from physiolabxr.ui.SliderWithValueLabel import SliderWithValueLabel
 from physiolabxr.utils.Validators import NoCommaIntValidator
 
@@ -94,6 +94,7 @@ class OptionsWindowPlotFormatWidget(QtWidgets.QWidget):
             self.imageHeightLineEdit.textChanged.disconnect()
             self.image_display_scaling_percentile_slider.valueChanged.disconnect()
             self.imageFormatComboBox.currentTextChanged.disconnect()
+            self.image_rotation_clockwise_degree_combobox.currentTextChanged.disconnect()
             self.channelFormatCombobox.currentTextChanged.disconnect()
             self.combobox_image_cmap.currentTextChanged.disconnect()
 
@@ -161,6 +162,7 @@ class OptionsWindowPlotFormatWidget(QtWidgets.QWidget):
         self.imageHeightLineEdit.textChanged.connect(self.image_w_h_scaling_percentile_on_change)
         self.image_display_scaling_percentile_slider.valueChanged.connect(self.image_scaling_percentile_on_change)
         self.imageFormatComboBox.currentTextChanged.connect(self.image_format_change)
+        self.image_rotation_clockwise_degree_combobox.currentTextChanged.connect(self.image_rotation_clockwise_degree_change)
         self.channelFormatCombobox.currentTextChanged.connect(self.image_channel_format_change)
 
         # barplot ###############################################################
@@ -245,6 +247,11 @@ class OptionsWindowPlotFormatWidget(QtWidgets.QWidget):
             self.pixelmap_display_options.setVisible(True)
         self.image_changed()
 
+    def image_rotation_clockwise_degree_change(self):
+        rotation_clockwise_degree = self.get_image_rotation_clockwise_degree()
+        set_group_image_rotation_clockwise_degree(self.stream_name, self.group_name, rotation_clockwise_degree=rotation_clockwise_degree)
+        self.image_changed()
+
     def image_channel_format_change(self):
         image_channel_format = self.get_image_channel_format()
         set_group_image_channel_format(self.stream_name, self.group_name, channel_format=image_channel_format)
@@ -309,6 +316,10 @@ class OptionsWindowPlotFormatWidget(QtWidgets.QWidget):
         current_format = self.imageFormatComboBox.currentText()
         # image_channel_num = image_depth_dict(current_format)
         return ImageFormat.__members__[current_format]
+
+    def get_image_rotation_clockwise_degree(self):
+        current_degree = self.image_rotation_clockwise_degree_combobox.currentText()
+        return int(current_degree)
 
     def get_image_channel_format(self):
         current_format = self.channelFormatCombobox.currentText()

--- a/physiolabxr/utils/image_utils.py
+++ b/physiolabxr/utils/image_utils.py
@@ -30,20 +30,4 @@ def rotate_image(image, rotation_clockwise_degree: int=0):
         return cv2.rotate(image, cv2.ROTATE_90_COUNTERCLOCKWISE)
 
 
-# def rotate_image(image, rotation_clockwise_degree: int=0, image_format: ImageFormat=ImageFormat.pixelmap, channel_format: ChannelFormat=ChannelFormat.channel_last):
-#     pass
-#     # if rgb_channel_order is not None:
-#     #     if rgb_channel_order == VideoDeviceChannelOrder.BGR:
-#     #         image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
-#     #     elif rgb_channel_order == VideoDeviceChannelOrder.RGB:
-#     #         pass
-#     #
-#     # if rotation_clockwise_degree==0:
-#     #     return image
-#     # elif rotation_clockwise_degree==90:
-#     #     return cv2.rotate(image, cv2.ROTATE_90_CLOCKWISE)
-#     # elif rotation_clockwise_degree==180:
-#     #     return cv2.rotate(image, cv2.ROTATE_180)
-#     # elif rotation_clockwise_degree==270:
-#     #     return cv2.rotate(image, cv2.ROTATE_90_COUNTERCLOCKWISE)
-#
+

--- a/physiolabxr/utils/image_utils.py
+++ b/physiolabxr/utils/image_utils.py
@@ -1,5 +1,7 @@
 import cv2
+import numpy
 
+from physiolabxr.presets.PlotConfig import ImageFormat, ChannelFormat
 from physiolabxr.presets.PresetEnums import VideoDeviceChannelOrder
 
 
@@ -15,3 +17,33 @@ def process_image(image, rgb_channel_order: VideoDeviceChannelOrder=None, scale:
 
     image = cv2.resize(image, (new_width, new_height), interpolation=cv2.INTER_NEAREST)
     return image
+
+
+def rotate_image(image, rotation_clockwise_degree: int=0):
+    if rotation_clockwise_degree==0:
+        return image
+    elif rotation_clockwise_degree==90:
+        return cv2.rotate(image, cv2.ROTATE_90_CLOCKWISE)
+    elif rotation_clockwise_degree==180:
+        return cv2.rotate(image, cv2.ROTATE_180)
+    elif rotation_clockwise_degree==270:
+        return cv2.rotate(image, cv2.ROTATE_90_COUNTERCLOCKWISE)
+
+
+# def rotate_image(image, rotation_clockwise_degree: int=0, image_format: ImageFormat=ImageFormat.pixelmap, channel_format: ChannelFormat=ChannelFormat.channel_last):
+#     pass
+#     # if rgb_channel_order is not None:
+#     #     if rgb_channel_order == VideoDeviceChannelOrder.BGR:
+#     #         image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
+#     #     elif rgb_channel_order == VideoDeviceChannelOrder.RGB:
+#     #         pass
+#     #
+#     # if rotation_clockwise_degree==0:
+#     #     return image
+#     # elif rotation_clockwise_degree==90:
+#     #     return cv2.rotate(image, cv2.ROTATE_90_CLOCKWISE)
+#     # elif rotation_clockwise_degree==180:
+#     #     return cv2.rotate(image, cv2.ROTATE_180)
+#     # elif rotation_clockwise_degree==270:
+#     #     return cv2.rotate(image, cv2.ROTATE_90_COUNTERCLOCKWISE)
+#


### PR DESCRIPTION
fix image format channel first/channel last reversed bug, finish image rotation. it works for rgb,bgr, and pixel map. feature tested
user can select rotate clockwise 0,90,180.270 degrees
