### PR TITLE
Image rotation pr

### DIFF
--- a/physiolabxr/_ui/OptionsWindowPlotFormatWidget.ui
+++ b/physiolabxr/_ui/OptionsWindowPlotFormatWidget.ui
@@ -20,7 +20,7 @@
    <item>
     <widget class="QTabWidget" name="plotFormatTabWidget">
      <property name="currentIndex">
-      <number>0</number>
+      <number>1</number>
      </property>
      <property name="iconSize">
       <size>
@@ -133,10 +133,47 @@
             <x>0</x>
             <y>0</y>
             <width>809</width>
-            <height>362</height>
+            <height>410</height>
            </rect>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_13">
+           <item>
+            <widget class="QWidget" name="image_rotation_clockwise_degree_widget" native="true">
+             <layout class="QHBoxLayout" name="horizontalLayout_7">
+              <item>
+               <widget class="QLabel" name="image_rotation_clockwise_degree_label">
+                <property name="text">
+                 <string>Rotation (Clockwise in Degree)</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QComboBox" name="image_rotation_clockwise_degree_combobox">
+                <item>
+                 <property name="text">
+                  <string>0</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>90</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>180</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>270</string>
+                 </property>
+                </item>
+               </widget>
+              </item>
+             </layout>
+            </widget>
+           </item>
            <item>
             <widget class="QWidget" name="display_options" native="true">
              <layout class="QVBoxLayout" name="verticalLayout_12">

--- a/physiolabxr/presets/PlotConfig.py
+++ b/physiolabxr/presets/PlotConfig.py
@@ -32,6 +32,8 @@ class ImageConfig(metaclass=SubPreset):
     width: int = 0
     height: int = 0
     rotation_clockwise_degree: int = 0
+    # horizontal_flip: bool = False
+    # vertical_flip: bool = False
     scaling_percentage: float = 100
 
     cmap: Cmap = Cmap.VIRIDIS

--- a/physiolabxr/presets/PlotConfig.py
+++ b/physiolabxr/presets/PlotConfig.py
@@ -31,6 +31,7 @@ class ImageConfig(metaclass=SubPreset):
 
     width: int = 0
     height: int = 0
+    rotation_clockwise_degree: int = 0
     scaling_percentage: float = 100
 
     cmap: Cmap = Cmap.VIRIDIS

--- a/physiolabxr/presets/presets_utils.py
+++ b/physiolabxr/presets/presets_utils.py
@@ -119,6 +119,9 @@ def get_bar_chart_max_min_range(stream_name, group_name) -> tuple[float, float]:
 def set_group_image_format(stream_name, group_name, image_format):
     Presets().stream_presets[stream_name].group_info[group_name].plot_configs.image_config.image_format = image_format
 
+def set_group_image_rotation_clockwise_degree(stream_name, group_name, rotation_clockwise_degree):
+    Presets().stream_presets[stream_name].group_info[group_name].plot_configs.image_config.rotation_clockwise_degree = rotation_clockwise_degree
+
 def get_group_image_format(stream_name, group_name):
     return Presets().stream_presets[stream_name].group_info[group_name].plot_configs.image_config.image_format
 

--- a/physiolabxr/ui/GroupPlotWidget.py
+++ b/physiolabxr/ui/GroupPlotWidget.py
@@ -14,7 +14,7 @@ from physiolabxr.presets.presets_utils import get_stream_preset_info, get_is_gro
     spectrogram_time_second_overlap, get_spectrogram_cmap_lut, get_spectrogram_percentile_level_max, \
     get_spectrogram_percentile_level_min, get_image_cmap_lut, get_valid_image_levels, \
     get_group_channel_indices_start_end, get_is_channels_show
-from physiolabxr.utils.image_utils import process_image
+from physiolabxr.utils.image_utils import process_image, rotate_image
 from physiolabxr.utils.ui_utils import get_distinct_colors
 
 
@@ -198,7 +198,12 @@ class GroupPlotWidget(QtWidgets.QWidget):
 
         elif selected_plot_format == 1 and get_group_image_valid(self.stream_name, self.group_name):
             image_config = get_group_image_config(self.stream_name, self.group_name)
-            width, height, image_format, channel_format, scaling_percentile = image_config.width, image_config.height, image_config.image_format, image_config.channel_format, image_config.scaling_percentage
+            width, height, image_format, channel_format, scaling_percentile, rotation_clockwise_degree = image_config.width, \
+                                                                                                         image_config.height, \
+                                                                                                         image_config.image_format, \
+                                                                                                         image_config.channel_format, \
+                                                                                                         image_config.scaling_percentage, \
+                                                                                                         image_config.rotation_clockwise_degree
             depth = image_format.depth_dim()
             if channel_indices is None:
                 start_end = get_group_channel_indices_start_end(self.stream_name, self.group_name)
@@ -206,10 +211,10 @@ class GroupPlotWidget(QtWidgets.QWidget):
             else:
                 image_plot_data = data[channel_indices, -1]  # only visualize the last frame
             if image_format == ImageFormat.rgb or image_format == ImageFormat.bgr:
-                if channel_format == ChannelFormat.channel_last:
+                if channel_format == ChannelFormat.channel_first:
                     image_plot_data = np.reshape(image_plot_data, (depth, height, width))
                     image_plot_data = np.moveaxis(image_plot_data, 0, -1)
-                elif channel_format == ChannelFormat.channel_first:
+                elif channel_format == ChannelFormat.channel_last:
                     image_plot_data = np.reshape(image_plot_data, (height, width, depth))
                 # it's always channel last when we are done
                 if image_format == ImageFormat.bgr:
@@ -222,6 +227,12 @@ class GroupPlotWidget(QtWidgets.QWidget):
                 self.image_item.setLevels(get_valid_image_levels(self.stream_name, self.group_name))
             if scaling_percentile != 100:
                 image_plot_data = process_image(image_plot_data, scale=scaling_percentile/100)
+            if rotation_clockwise_degree != 0:
+                # the image should already been formatted to channel last and RGB
+                image_plot_data = rotate_image(image_plot_data, rotation_clockwise_degree=rotation_clockwise_degree)
+                # image_plot_data = process_image(image_plot_data, rotate=rotation_clockwise_degree)
+                # pass
+
             self.image_item.setImage(image_plot_data, autoLevels=self.is_auto_level_image)
 
         elif selected_plot_format == 2:
@@ -289,4 +300,3 @@ class GroupPlotWidget(QtWidgets.QWidget):
             self.is_auto_level_image = True
         elif levels is not None:
             self.is_auto_level_image = False
-

--- a/physiolabxr/ui/OptionsWindowPlotFormatWidget.py
+++ b/physiolabxr/ui/OptionsWindowPlotFormatWidget.py
@@ -121,6 +121,7 @@ class OptionsWindowPlotFormatWidget(QtWidgets.QWidget):
         self.image_display_scaling_percentile_slider.setValue(this_group_entry.plot_configs.image_config.scaling_percentage)
 
         self.imageFormatComboBox.setCurrentText(this_group_entry.plot_configs.image_config.image_format.name)
+        self.image_rotation_clockwise_degree_combobox.setCurrentText(str(this_group_entry.plot_configs.image_config.rotation_clockwise_degree))
         self.channelFormatCombobox.setCurrentText(this_group_entry.plot_configs.image_config.channel_format.name)
 
         valid_levels = get_valid_image_levels(self.stream_name, group_name)

--- a/physiolabxr/ui/OptionsWindowPlotFormatWidget.py
+++ b/physiolabxr/ui/OptionsWindowPlotFormatWidget.py
@@ -15,7 +15,7 @@ from physiolabxr.presets.presets_utils import get_stream_a_group_info, \
     set_spectrogram_percentile_level_min, set_spectrogram_percentile_level_max, set_image_levels_max, \
     set_image_levels_min, get_valid_image_levels, set_image_cmap, \
     set_image_levels_rmin, set_image_levels_bmax, set_image_levels_bmin, set_image_levels_gmax, set_image_levels_gmin, \
-    set_image_levels_rmax, set_image_scaling_percentile, get_image_levels
+    set_image_levels_rmax, set_image_scaling_percentile, get_image_levels, set_group_image_rotation_clockwise_degree
 from physiolabxr.ui.SliderWithValueLabel import SliderWithValueLabel
 from physiolabxr.utils.Validators import NoCommaIntValidator
 
@@ -94,6 +94,7 @@ class OptionsWindowPlotFormatWidget(QtWidgets.QWidget):
             self.imageHeightLineEdit.textChanged.disconnect()
             self.image_display_scaling_percentile_slider.valueChanged.disconnect()
             self.imageFormatComboBox.currentTextChanged.disconnect()
+            self.image_rotation_clockwise_degree_combobox.currentTextChanged.disconnect()
             self.channelFormatCombobox.currentTextChanged.disconnect()
             self.combobox_image_cmap.currentTextChanged.disconnect()
 
@@ -161,6 +162,7 @@ class OptionsWindowPlotFormatWidget(QtWidgets.QWidget):
         self.imageHeightLineEdit.textChanged.connect(self.image_w_h_scaling_percentile_on_change)
         self.image_display_scaling_percentile_slider.valueChanged.connect(self.image_scaling_percentile_on_change)
         self.imageFormatComboBox.currentTextChanged.connect(self.image_format_change)
+        self.image_rotation_clockwise_degree_combobox.currentTextChanged.connect(self.image_rotation_clockwise_degree_change)
         self.channelFormatCombobox.currentTextChanged.connect(self.image_channel_format_change)
 
         # barplot ###############################################################
@@ -245,6 +247,11 @@ class OptionsWindowPlotFormatWidget(QtWidgets.QWidget):
             self.pixelmap_display_options.setVisible(True)
         self.image_changed()
 
+    def image_rotation_clockwise_degree_change(self):
+        rotation_clockwise_degree = self.get_image_rotation_clockwise_degree()
+        set_group_image_rotation_clockwise_degree(self.stream_name, self.group_name, rotation_clockwise_degree=rotation_clockwise_degree)
+        self.image_changed()
+
     def image_channel_format_change(self):
         image_channel_format = self.get_image_channel_format()
         set_group_image_channel_format(self.stream_name, self.group_name, channel_format=image_channel_format)
@@ -309,6 +316,10 @@ class OptionsWindowPlotFormatWidget(QtWidgets.QWidget):
         current_format = self.imageFormatComboBox.currentText()
         # image_channel_num = image_depth_dict(current_format)
         return ImageFormat.__members__[current_format]
+
+    def get_image_rotation_clockwise_degree(self):
+        current_degree = self.image_rotation_clockwise_degree_combobox.currentText()
+        return int(current_degree)
 
     def get_image_channel_format(self):
         current_format = self.channelFormatCombobox.currentText()

--- a/physiolabxr/utils/image_utils.py
+++ b/physiolabxr/utils/image_utils.py
@@ -1,5 +1,7 @@
 import cv2
+import numpy
 
+from physiolabxr.presets.PlotConfig import ImageFormat, ChannelFormat
 from physiolabxr.presets.PresetEnums import VideoDeviceChannelOrder
 
 
@@ -15,3 +17,16 @@ def process_image(image, rgb_channel_order: VideoDeviceChannelOrder=None, scale:
 
     image = cv2.resize(image, (new_width, new_height), interpolation=cv2.INTER_NEAREST)
     return image
+
+
+def rotate_image(image, rotation_clockwise_degree: int=0):
+    if rotation_clockwise_degree==0:
+        return image
+    elif rotation_clockwise_degree==90:
+        return cv2.rotate(image, cv2.ROTATE_90_CLOCKWISE)
+    elif rotation_clockwise_degree==180:
+        return cv2.rotate(image, cv2.ROTATE_180)
+    elif rotation_clockwise_degree==270:
+        return cv2.rotate(image, cv2.ROTATE_90_COUNTERCLOCKWISE)
+
+


### PR DESCRIPTION
fix image format channel first/channel last reversed bug, finish image rotation. 
it works for rgb, bgr, and pixel map. feature tested user can select rotate clockwise 0,90,180.270 degrees from the combobox